### PR TITLE
Make cell values wrap from 127 to -128

### DIFF
--- a/brain_friendly.py
+++ b/brain_friendly.py
@@ -11,9 +11,9 @@ def eval_program(program_string, index, array):
         # Python doesn't have switch statements?
         if command == "+":
             # Cells are signed 8-bit values
-            increment_command(array[index])
+            array[index] = increment_command(array[index])
         elif command == "-":
-            decrement_command(array[index])
+            array[index] = decrement_command(array[index])
         elif command == ">":
             index += 1
         elif command == "<":

--- a/brain_friendly.py
+++ b/brain_friendly.py
@@ -11,15 +11,9 @@ def eval_program(program_string, index, array):
         # Python doesn't have switch statements?
         if command == "+":
             # Cells are signed 8-bit values
-            if array[index] == 127:
-                array[index] = -128
-            else:
-                array[index] += 1
+            increment_command(array[index])
         elif command == "-":
-            if array[index] == -128:
-                array[index] = 127
-            else:
-                array[index] -= 1
+            decrement_command(array[index])
         elif command == ">":
             index += 1
         elif command == "<":
@@ -29,6 +23,18 @@ def eval_program(program_string, index, array):
             else:
                 index -= 1
     return array
+
+def increment_command(value):
+    if value == 127:
+        return -128
+    else:
+        return value + 1
+
+def decrement_command(value):
+    if value == -128:
+        return 127
+    else:
+        return value - 1
 
 bf_array[0] = 127 # This is to show an example of cell-wrapping.
 bf_array[1] = -128

--- a/brain_friendly.py
+++ b/brain_friendly.py
@@ -1,5 +1,5 @@
 # The input BF program.
-bf_program_string = "+>+>+>+>++>>-->>++<--<<<<++++++--"
+bf_program_string = "++++++>----"
 # Current pointer location.
 bf_index = 0
 # Array of byte cells (currently 30,000).
@@ -10,9 +10,16 @@ def eval_program(program_string, index, array):
     for command in program_string:
         # Python doesn't have switch statements?
         if command == "+":
-            array[index] += 1
+            # Cells are signed 8-bit values
+            if array[index] == 127:
+                array[index] = -128
+            else:
+                array[index] += 1
         elif command == "-":
-            array[index] -= 1
+            if array[index] == -128:
+                array[index] = 127
+            else:
+                array[index] -= 1
         elif command == ">":
             index += 1
         elif command == "<":
@@ -23,4 +30,9 @@ def eval_program(program_string, index, array):
                 index -= 1
     return array
 
-print(eval_program(bf_program_string, bf_index, bf_array))
+bf_array[0] = 127 # This is to show an example of cell-wrapping.
+bf_array[1] = -128
+
+bf_array = eval_program(bf_program_string, bf_index, bf_array)
+
+print(bf_array[0:10])


### PR DESCRIPTION
In BF, cells are typically signed or unsigned 8 bit values. For BrainFriendly, we'll use signed 8bit values.

End print statement only prints the first ten cells instead of all 30,000 cells.

The example program now displays an example of cell wrapping.
